### PR TITLE
Fix template link and add requirements documentation

### DIFF
--- a/data/templates/confirmation.html.hbs
+++ b/data/templates/confirmation.html.hbs
@@ -67,7 +67,7 @@
                 </p>
                 <p style="margin:0 0 16px 0;">
                   Want to make any changes? Give us a call at
-                  <a class="link" href="tel:{phoneLink}">{{phoneformatted}}</a>.
+                  <a class="link" href="tel:{{phoneLink}}">{{phoneformatted}}</a>.
                   {{menuText}}
                   <a class="link" href="{{menuLink}}">here</a>.
                 </p>

--- a/requirements.md
+++ b/requirements.md
@@ -1,0 +1,43 @@
+# Templating Requirements
+
+This document outlines the requirements and conventions for the email templating system.
+
+## Template Variables
+
+There are two types of variables used in the email templates:
+
+### 1. Handlebars Variables (`{{...}}`)
+
+-   **Syntax:** `{{variableName}}`
+-   **Source:** These variables are populated by the backend server (`server.js`).
+-   **Data Source:** The data for these variables comes from the JSON files located in the `data/venues/` directory (e.g., `SoulBar.json`).
+-   **Purpose:** Used for venue-specific information that is known at the time of rendering, such as header images, addresses, and links.
+
+**Example:**
+
+```html
+<img src="{{headerImage}}" width="600" alt="{{templateTitle}}">
+```
+
+In this example, `headerImage` and `templateTitle` are supplied by the corresponding venue's JSON file.
+
+### 2. External System Placeholders (`[...]`)
+
+-   **Syntax:** `[PLACEHOLDER_NAME]`
+-   **Source:** These placeholders are **not** processed by this application. They are intended to be replaced by an external system that consumes the rendered HTML output.
+-   **Purpose:** Used for booking-specific information that is not available to this application, such as customer names, booking times, and confirmation numbers.
+
+**Example:**
+
+```html
+<p>Dear [FULLNAME]</p>
+<p>Table reservation for <strong>[COVERS]</strong> people on <strong>[DATE]</strong> at <strong>[TIME]</strong></p>
+```
+
+In this example, `[FULLNAME]`, `[COVERS]`, `[DATE]`, and `[TIME]` are expected to be replaced by a downstream application.
+
+## Best Practices
+
+-   When editing templates, use `{{...}}` for data that is stored in the `data/venues/` JSON files.
+-   Use `[...]` for data that will be injected later by the external booking system.
+-   Do not mix the two syntaxes for the same purpose.


### PR DESCRIPTION
This commit addresses two issues:

1.  It fixes a broken `tel:` link in the `confirmation.html.hbs` template. The link was incorrectly formatted as `tel:{phoneLink}` instead of using the Handlebars syntax `tel:{{phoneLink}}`.

2.  It adds a `requirements.md` file to document the templating conventions used in the project. This file clarifies the distinction between Handlebars variables (`{{...}}`), which are processed by this application, and bracketed placeholders (`[...]`), which are intended for an external system. This documentation will help future developers understand how to work with the templates.